### PR TITLE
Add localization support for English and Spanish

### DIFF
--- a/AppleShowsFeedApp/AppleShowsFeedApp.xcodeproj/project.pbxproj
+++ b/AppleShowsFeedApp/AppleShowsFeedApp.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 			knownRegions = (
 				en,
 				Base,
+				es,
 			);
 			mainGroup = CE889A512E842C4600FB7AD1;
 			minimizedProjectReferenceProxies = 1;

--- a/AppleShowsFeedApp/AppleShowsFeedApp.xcodeproj/project.pbxproj
+++ b/AppleShowsFeedApp/AppleShowsFeedApp.xcodeproj/project.pbxproj
@@ -304,6 +304,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -360,6 +361,7 @@
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/AppleShowsFeedApp/AppleShowsFeedApp/AppleShowsFeedApp.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/AppleShowsFeedApp.swift
@@ -11,7 +11,7 @@ import AppleShowsFeed
 @main
 struct AppleShowsFeedApp: App {
     /// Hardcoded country value to simply display different feeds by country.
-    @State private var selectedCountry: Storefront = .canada
+    @State private var selectedStore: Storefront = .canada
     @State private var router = Router()
     
     private static let httpClient: HTTPClient = {
@@ -28,7 +28,7 @@ struct AppleShowsFeedApp: App {
         WindowGroup {
             NavigationStack(path: $router.path) {
                 MoviesListUIComposer.composedWith(
-                    loader: makeLoader(for: selectedCountry.id),
+                    loader: makeLoader(for: selectedStore.id),
                     onSelection: { movie in
                         let viewModel = MovieDetailsViewModel(
                             imageURL: movie.images.last?.url,
@@ -44,10 +44,10 @@ struct AppleShowsFeedApp: App {
                         router.navigate(to: .movieDetails(viewModel))
                     }
                 )
-                .id(selectedCountry.id)
+                .id(selectedStore.id)
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
-                        LanguagePicker(selectedCountry: $selectedCountry)
+                        LanguagePicker(selectedCountry: $selectedStore)
                     }
                 }
                 .navigationDestination(for: Router.Destination.self) { destination in

--- a/AppleShowsFeedApp/AppleShowsFeedApp/AppleShowsFeedApp.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/AppleShowsFeedApp.swift
@@ -47,7 +47,7 @@ struct AppleShowsFeedApp: App {
                 .id(selectedStore.id)
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
-                        LanguagePicker(selectedCountry: $selectedStore)
+                        LanguagePicker(selectedStore: $selectedStore)
                     }
                 }
                 .navigationDestination(for: Router.Destination.self) { destination in

--- a/AppleShowsFeedApp/AppleShowsFeedApp/AppleShowsFeedApp.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/AppleShowsFeedApp.swift
@@ -57,6 +57,7 @@ struct AppleShowsFeedApp: App {
                     }
                 }
             }
+            .environment(\.locale, selectedStore.locale)
         }
     }
 }

--- a/AppleShowsFeedApp/AppleShowsFeedApp/AppleShowsFeedApp.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/AppleShowsFeedApp.swift
@@ -11,7 +11,7 @@ import AppleShowsFeed
 @main
 struct AppleShowsFeedApp: App {
     /// Hardcoded country value to simply display different feeds by country.
-    @State private var selectedCountry: Country = .canada
+    @State private var selectedCountry: Storefront = .canada
     @State private var router = Router()
     
     private static let httpClient: HTTPClient = {

--- a/AppleShowsFeedApp/AppleShowsFeedApp/Domain/Storefront.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/Domain/Storefront.swift
@@ -1,5 +1,5 @@
 //
-//  Country.swift
+//  Storefront.swift
 //  AppleShowsFeedApp
 //
 //  Created by Oswaldo Maestra on 26/09/2025.
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Hardcoded country values only for simply display different feeds by country.
-enum Country: String, CaseIterable, Identifiable {
+enum Storefront: String, CaseIterable, Identifiable {
     case canada = "ca"
     case spain = "es"
     

--- a/AppleShowsFeedApp/AppleShowsFeedApp/Domain/Storefront.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/Domain/Storefront.swift
@@ -15,8 +15,8 @@ public enum Storefront: String, CaseIterable, Identifiable {
     public var id: String { rawValue }
     public var displayName: String {
         switch self {
-        case .canada: return "🇨🇦 Canada Store"
-        case .spain: return "🇪🇸 Spain Store"
+        case .canada: return String(localized: "storefront.canada.label", locale: self.locale)
+        case .spain: return String(localized: "storefront.spain.label", locale: self.locale)
         }
     }
     

--- a/AppleShowsFeedApp/AppleShowsFeedApp/Domain/Storefront.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/Domain/Storefront.swift
@@ -15,8 +15,8 @@ public enum Storefront: String, CaseIterable, Identifiable {
     public var id: String { rawValue }
     public var displayName: String {
         switch self {
-        case .canada: return "🇨🇦 Canada"
-        case .spain: return "🇪🇸 Spain"
+        case .canada: return "🇨🇦 Canada Store"
+        case .spain: return "🇪🇸 Spain Store"
         }
     }
 }

--- a/AppleShowsFeedApp/AppleShowsFeedApp/Domain/Storefront.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/Domain/Storefront.swift
@@ -13,10 +13,10 @@ public enum Storefront: String, CaseIterable, Identifiable {
     case spain = "es"
     
     public var id: String { rawValue }
-    public var displayName: String {
+    public var displayName: LocalizedStringResource {
         switch self {
-        case .canada: return String(localized: "storefront.canada.label", locale: self.locale)
-        case .spain: return String(localized: "storefront.spain.label", locale: self.locale)
+        case .canada: return LocalizedStringResource(stringLiteral: "storefront.canada.label")
+        case .spain: return LocalizedStringResource(stringLiteral: "storefront.spain.label")
         }
     }
     

--- a/AppleShowsFeedApp/AppleShowsFeedApp/Domain/Storefront.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/Domain/Storefront.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 /// Hardcoded country values only for simply display different feeds by country.
-enum Storefront: String, CaseIterable, Identifiable {
+public enum Storefront: String, CaseIterable, Identifiable {
     case canada = "ca"
     case spain = "es"
     
-    var id: String { rawValue }
-    var displayName: String {
+    public var id: String { rawValue }
+    public var displayName: String {
         switch self {
         case .canada: return "🇨🇦 Canada"
         case .spain: return "🇪🇸 Spain"

--- a/AppleShowsFeedApp/AppleShowsFeedApp/Domain/Storefront.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/Domain/Storefront.swift
@@ -19,4 +19,11 @@ public enum Storefront: String, CaseIterable, Identifiable {
         case .spain: return "🇪🇸 Spain Store"
         }
     }
+    
+    public var locale: Locale {
+        switch self {
+        case .canada: Locale(identifier: "en_CA")
+        case .spain: Locale(identifier: "es_ES")
+        }
+    }
 }

--- a/AppleShowsFeedApp/AppleShowsFeedApp/Localizable.xcstrings
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/Localizable.xcstrings
@@ -1,0 +1,7 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+
+  },
+  "version" : "1.0"
+}

--- a/AppleShowsFeedApp/AppleShowsFeedApp/Localizable.xcstrings
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/Localizable.xcstrings
@@ -1,7 +1,183 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-
+    "artist.label" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "By:"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Por:"
+          }
+        }
+      }
+    },
+    "buyFor.label" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buy for:"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprar por:"
+          }
+        }
+      }
+    },
+    "error.no.summary.description" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maybe you just need to watch it to figure it out."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tal vez solo tienes que verla para resolverlo."
+          }
+        }
+      }
+    },
+    "error.no.summary.label" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There is no summary for this movie"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No existe resumen para esta película"
+          }
+        }
+      }
+    },
+    "movie.summary" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Summary"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resumen"
+          }
+        }
+      }
+    },
+    "movies.state.loading.label" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading awesome movies…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando películas geniales…"
+          }
+        }
+      }
+    },
+    "price.buy.label" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprar"
+          }
+        }
+      }
+    },
+    "price.rent.label" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rent"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alquilar"
+          }
+        }
+      }
+    },
+    "released.label" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Released:"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publicada:"
+          }
+        }
+      }
+    },
+    "rentFor.label" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rent for:"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alquilar por:"
+          }
+        }
+      }
+    },
+    "storefront.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Storefront"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tienda"
+          }
+        }
+      }
+    }
   },
   "version" : "1.0"
 }

--- a/AppleShowsFeedApp/AppleShowsFeedApp/Localizable.xcstrings
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/Localizable.xcstrings
@@ -161,6 +161,38 @@
         }
       }
     },
+    "storefront.canada.label" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Canada store"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tienda de Canada"
+          }
+        }
+      }
+    },
+    "storefront.spain.label" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spain store"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tienda de España"
+          }
+        }
+      }
+    },
     "storefront.title" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/AppleShowsFeedApp/AppleShowsFeedApp/View/LanguagePicker.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/View/LanguagePicker.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 struct LanguagePicker: View {
-    @Binding var selectedCountry: Country
+    @Binding var selectedCountry: Storefront
 
     var body: some View {
         Picker("Country", selection: $selectedCountry) {
-            ForEach(Country.allCases) { country in
+            ForEach(Storefront.allCases) { country in
                 Text(country.displayName).tag(country)
             }
         }

--- a/AppleShowsFeedApp/AppleShowsFeedApp/View/LanguagePicker.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/View/LanguagePicker.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct LanguagePicker: View {
-    @Binding var selectedCountry: Storefront
+    @Binding var selectedStore: Storefront
 
     var body: some View {
-        Picker("storefront.title", selection: $selectedCountry) {
+        Picker("storefront.title", selection: $selectedStore) {
             ForEach(Storefront.allCases) { country in
                 Text(country.displayName).tag(country)
             }
@@ -21,5 +21,5 @@ struct LanguagePicker: View {
 }
 
 #Preview {
-    LanguagePicker(selectedCountry: .constant(.canada))
+    LanguagePicker(selectedStore: .constant(.canada))
 }

--- a/AppleShowsFeedApp/AppleShowsFeedApp/View/LanguagePicker.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/View/LanguagePicker.swift
@@ -11,7 +11,7 @@ struct LanguagePicker: View {
     @Binding var selectedCountry: Storefront
 
     var body: some View {
-        Picker("Storefront", selection: $selectedCountry) {
+        Picker("storefront.title", selection: $selectedCountry) {
             ForEach(Storefront.allCases) { country in
                 Text(country.displayName).tag(country)
             }

--- a/AppleShowsFeedApp/AppleShowsFeedApp/View/LanguagePicker.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/View/LanguagePicker.swift
@@ -12,8 +12,8 @@ struct LanguagePicker: View {
 
     var body: some View {
         Picker("storefront.title", selection: $selectedStore) {
-            ForEach(Storefront.allCases) { country in
-                Text(country.displayName).tag(country)
+            ForEach(Storefront.allCases) { store in
+                Text(store.displayName).tag(store)
             }
         }
         .pickerStyle(.menu)

--- a/AppleShowsFeedApp/AppleShowsFeedApp/View/LanguagePicker.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/View/LanguagePicker.swift
@@ -11,7 +11,7 @@ struct LanguagePicker: View {
     @Binding var selectedCountry: Storefront
 
     var body: some View {
-        Picker("Country", selection: $selectedCountry) {
+        Picker("Storefront", selection: $selectedCountry) {
             ForEach(Storefront.allCases) { country in
                 Text(country.displayName).tag(country)
             }

--- a/AppleShowsFeedApp/AppleShowsFeedApp/View/MovieDetailsView.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/View/MovieDetailsView.swift
@@ -36,7 +36,7 @@ struct MovieDetailsView: View {
                         Spacer()
                         
                         Text("released.label").fontWeight(.semibold)
-                        + Text(" \(viewModel.releaseDateFormatted)")
+                        + Text(verbatim: " \(viewModel.releaseDateFormatted)")
                         
                         if let artist = viewModel.artist {
                             Text("artist.label").fontWeight(.semibold)

--- a/AppleShowsFeedApp/AppleShowsFeedApp/View/MovieDetailsView.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/View/MovieDetailsView.swift
@@ -35,9 +35,12 @@ struct MovieDetailsView: View {
                         
                         Spacer()
                         
-                        Text.init("**Released:** \(viewModel.releaseDate.formatted(date: .long, time: .omitted))")
+                        Text("released.label").fontWeight(.semibold)
+                        + Text(" \(viewModel.releaseDateFormatted)")
+                        
                         if let artist = viewModel.artist {
-                            Text.init("**By:** \(artist)")
+                            Text("artist.label").fontWeight(.semibold)
+                            + Text(verbatim: " \(artist)")
                         }
                     }
                     
@@ -46,9 +49,9 @@ struct MovieDetailsView: View {
                 
                 Grid(alignment: .center) {
                     GridRow {
-                        Text("Buy")
+                        Text("price.buy.label")
                             .fontWeight(.semibold)
-                        Text("Rent")
+                        Text("price.rent.label")
                             .fontWeight(.semibold)
                     }
                     Spacer()
@@ -66,20 +69,36 @@ struct MovieDetailsView: View {
                                 .foregroundStyle(.white)
                                 .clipShape(RoundedRectangle(cornerRadius: 8))
                         } else {
-                            Text("-")
+                            Text(verbatim: "-")
                         }
                     }
                 }
                 
                 if let summary = viewModel.summary {
                     VStack(alignment: .leading, spacing: 24) {
-                        Text("Summary:")
+                        Text("movie.summary")
                             .font(.title2)
                             .fontWeight(.semibold)
-                        Text(summary)
+                        Text(verbatim: summary)
                             .lineSpacing(4)
                             .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
+                } else {
+                    VStack(spacing: 16) {
+                        Image(systemName: "binoculars")
+                            .font(.system(size: 48))
+                        
+                        VStack(spacing: 8) {
+                            Text("error.no.summary.label")
+                                .fontWeight(.semibold)
+                            Text("error.no.summary.description")
+                                .font(.footnote)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .foregroundStyle(.secondary)
+                    .padding()
                 }
             }
             .padding()

--- a/AppleShowsFeedApp/AppleShowsFeedApp/View/MovieDetailsView.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/View/MovieDetailsView.swift
@@ -36,7 +36,7 @@ struct MovieDetailsView: View {
                         Spacer()
                         
                         Text("released.label").fontWeight(.semibold)
-                        + Text(verbatim: " \(viewModel.releaseDateFormatted)")
+                        + Text(verbatim: " \(viewModel.releaseDate.formatted(date: .numeric, time: .omitted))")
                         
                         if let artist = viewModel.artist {
                             Text("artist.label").fontWeight(.semibold)

--- a/AppleShowsFeedApp/AppleShowsFeedApp/View/MoviesListView.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/View/MoviesListView.swift
@@ -28,7 +28,7 @@ struct MoviesListView: View {
         .listStyle(.plain)
         .overlay {
             if viewModel.isLoading, viewModel.movies.isEmpty {
-                ProgressView("Loading awesome movies...")
+                ProgressView("movies.state.loading.label")
             }
             if let error = viewModel.error {
                 VStack(spacing: 16) {
@@ -86,13 +86,13 @@ struct MovieCellView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     if let rentalPrice = viewModel.rentalPrice {
                         HStack {
-                            Text("Rent for:")
+                            Text("rentFor.label")
                                 .fontWeight(.semibold)
                             Text(rentalPrice)
                         }
                     }
                     HStack {
-                        Text("Buy for:")
+                        Text("buyFor.label")
                             .fontWeight(.semibold)
                         Text(viewModel.price)
                     }

--- a/AppleShowsFeedApp/AppleShowsFeedApp/ViewModel/MovieDetailsViewModel.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/ViewModel/MovieDetailsViewModel.swift
@@ -17,10 +17,6 @@ public struct MovieDetailsViewModel: Hashable {
     public let rentalPrice: String?
     public let summary: String?
     
-    public var releaseDateFormatted: String {
-        releaseDate.formatted(date: .numeric, time: .omitted)
-    }
-    
     public init(
         imageURL: URL?, 
         name: String, 

--- a/AppleShowsFeedApp/AppleShowsFeedApp/ViewModel/MovieDetailsViewModel.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedApp/ViewModel/MovieDetailsViewModel.swift
@@ -17,6 +17,10 @@ public struct MovieDetailsViewModel: Hashable {
     public let rentalPrice: String?
     public let summary: String?
     
+    public var releaseDateFormatted: String {
+        releaseDate.formatted(date: .numeric, time: .omitted)
+    }
+    
     public init(
         imageURL: URL?, 
         name: String, 

--- a/AppleShowsFeedApp/AppleShowsFeedAppTests/StorefrontTests.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedAppTests/StorefrontTests.swift
@@ -22,4 +22,9 @@ final class StorefrontTests: XCTestCase {
         XCTAssertEqual(Storefront.canada.displayName, "🇨🇦 Canada Store")
         XCTAssertEqual(Storefront.spain.displayName, "🇪🇸 Spain Store")
     }
+    
+    func test_locale_returnsExpectedLocales() {
+        XCTAssertEqual(Storefront.canada.locale.identifier, "en_CA")
+        XCTAssertEqual(Storefront.spain.locale.identifier, "es_ES")
+    }
 }

--- a/AppleShowsFeedApp/AppleShowsFeedAppTests/StorefrontTests.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedAppTests/StorefrontTests.swift
@@ -19,8 +19,8 @@ final class StorefrontTests: XCTestCase {
     }
     
     func test_displayName_returnsCorrectName() {
-        XCTAssertEqual(Storefront.canada.displayName, "🇨🇦 Canada Store")
-        XCTAssertEqual(Storefront.spain.displayName, "🇪🇸 Spain Store")
+        XCTAssertEqual(Storefront.canada.displayName, "Canada store")
+        XCTAssertEqual(Storefront.spain.displayName, "Spain store")
     }
     
     func test_locale_returnsExpectedLocales() {

--- a/AppleShowsFeedApp/AppleShowsFeedAppTests/StorefrontTests.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedAppTests/StorefrontTests.swift
@@ -17,4 +17,9 @@ final class StorefrontTests: XCTestCase {
         XCTAssertEqual(Storefront.canada.id, "ca")
         XCTAssertEqual(Storefront.spain.id, "es")
     }
+    
+    func test_displayName_returnsCorrectName() {
+        XCTAssertEqual(Storefront.canada.displayName, "🇨🇦 Canada Store")
+        XCTAssertEqual(Storefront.spain.displayName, "🇪🇸 Spain Store")
+    }
 }

--- a/AppleShowsFeedApp/AppleShowsFeedAppTests/StorefrontTests.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedAppTests/StorefrontTests.swift
@@ -6,7 +6,10 @@
 //
 
 import XCTest
+import AppleShowsFeedApp
 
 final class StorefrontTests: XCTestCase {
-
+    func test_allCases_returnsExpectedStorefronts() {
+        XCTAssertEqual(Storefront.allCases, [.canada, .spain])
+    }
 }

--- a/AppleShowsFeedApp/AppleShowsFeedAppTests/StorefrontTests.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedAppTests/StorefrontTests.swift
@@ -12,4 +12,9 @@ final class StorefrontTests: XCTestCase {
     func test_allCases_returnsExpectedStorefronts() {
         XCTAssertEqual(Storefront.allCases, [.canada, .spain])
     }
+    
+    func test_id_matchesRawValue() {
+        XCTAssertEqual(Storefront.canada.id, "ca")
+        XCTAssertEqual(Storefront.spain.id, "es")
+    }
 }

--- a/AppleShowsFeedApp/AppleShowsFeedAppTests/StorefrontTests.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedAppTests/StorefrontTests.swift
@@ -18,9 +18,10 @@ final class StorefrontTests: XCTestCase {
         XCTAssertEqual(Storefront.spain.id, "es")
     }
     
-    func test_displayName_returnsCorrectName() {
-        XCTAssertEqual(Storefront.canada.displayName, "Canada store")
-        XCTAssertEqual(Storefront.spain.displayName, "Spain store")
+    func test_displayName_returnsLocalizedName() {
+        
+        XCTAssertEqual(String(localized: Storefront.canada.displayName), String(localized: "storefront.canada.label"))
+        XCTAssertEqual(String(localized: Storefront.spain.displayName), String(localized: "storefront.spain.label"))
     }
     
     func test_locale_returnsExpectedLocales() {

--- a/AppleShowsFeedApp/AppleShowsFeedAppTests/StorefrontTests.swift
+++ b/AppleShowsFeedApp/AppleShowsFeedAppTests/StorefrontTests.swift
@@ -1,0 +1,12 @@
+//
+//  StorefrontTests.swift
+//  AppleShowsFeedAppTests
+//
+//  Created by Oswaldo Maestra on 30/09/2025.
+//
+
+import XCTest
+
+final class StorefrontTests: XCTestCase {
+
+}


### PR DESCRIPTION
Add in-app localization based on user's selected storefront to match iTunes API localized results based on parameters.